### PR TITLE
add static aws credential provider based on config

### DIFF
--- a/src/main/scala/kamon/cloudwatch/CloudWatchReporter.scala
+++ b/src/main/scala/kamon/cloudwatch/CloudWatchReporter.scala
@@ -28,7 +28,6 @@ final class CloudWatchModuleFactory extends ModuleFactory {
 
 final class CloudWatchReporter private[cloudwatch] (cfg: Configuration, clock: Clock)
     extends MetricReporter {
-  import CloudWatchReporter._
 
   private[this] val logger = LoggerFactory.getLogger(classOf[MetricsShipper].getPackage.getName)
 

--- a/src/test/scala/kamon/cloudwatch/CloudWatchReporterSpec.scala
+++ b/src/test/scala/kamon/cloudwatch/CloudWatchReporterSpec.scala
@@ -13,7 +13,6 @@ import com.typesafe.config.{Config, ConfigFactory}
 import kamon.tag.TagSet
 import kamon.testkit.MetricSnapshotBuilder
 
-
 import scala.jdk.CollectionConverters._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
This PR provides static credentials provider for the kamon-cloudwatch.
You can explicitly provide the AWS Credentials for Cloudwatch.


I don't know how to provide test for this functionality, so I'm looking forward to any suggestion.