### PR TITLE
Add WebIdentityTokenCredentialsProvider to AWS credentials chain

### DIFF
--- a/src/main/scala/kamon/cloudwatch/AmazonAsync.scala
+++ b/src/main/scala/kamon/cloudwatch/AmazonAsync.scala
@@ -26,6 +26,7 @@ private[cloudwatch] object AmazonAsync {
     new AWSCredentialsProviderChain(
       new EnvironmentVariableCredentialsProvider,
       new ProfileCredentialsProvider(),
+      new WebIdentityTokenCredentialsProvider,
       InstanceProfileCredentialsProvider.getInstance(),
       new EC2ContainerCredentialsProviderWrapper
     )


### PR DESCRIPTION
Adding in additional credentials provider to allow AWS credentials to be taken from web tokens, such as those used by IAM Roles for Service Accounts in EKS